### PR TITLE
Added the method clear to clear command queue in the Synthesizer

### DIFF
--- a/src/com/jsyn/Synthesizer.java
+++ b/src/com/jsyn/Synthesizer.java
@@ -185,4 +185,9 @@ public interface Synthesizer {
 
     public void removeAudioTask(Runnable task);
 
+    /**
+     * Clear the current command queue allocated.
+     */
+    void clear();
+
 }

--- a/src/com/jsyn/engine/SynthesisEngine.java
+++ b/src/com/jsyn/engine/SynthesisEngine.java
@@ -284,6 +284,10 @@ public class SynthesisEngine implements Runnable, Synthesizer {
             runningUnitList.clear();
         }
         started = false;
+        
+        synchronized (this.commandQueue) {//why not clear the commandQueue?
+            this.commandQueue = new ScheduledQueue<ScheduledCommand>();
+        }
     }
 
     @Override

--- a/src/com/jsyn/engine/SynthesisEngine.java
+++ b/src/com/jsyn/engine/SynthesisEngine.java
@@ -284,12 +284,15 @@ public class SynthesisEngine implements Runnable, Synthesizer {
             runningUnitList.clear();
         }
         started = false;
-        
-        synchronized (this.commandQueue) {//why not clear the commandQueue?
-            this.commandQueue = new ScheduledQueue<ScheduledCommand>();
-        }
     }
 
+    @Override
+    public void clear() {
+        synchronized (this.commandQueue) {//why not clear the commandQueue?
+            this.commandQueue = new ScheduledQueue<ScheduledCommand>();
+        }        
+    }
+    
     @Override
     public void run() {
         logger.fine("JSyn synthesis thread starting.");


### PR DESCRIPTION
Hello,

I added an method to allow me clear the command queue in the Synthesizer, dont you think it would be good to have a method like that?

Because currently, if I stop an try to regenerate and starts again, it continue from the last command not played, competing with the new queued commands.