### PR TITLE
Fix race condition when stopping and restarting the synthesizer.

### DIFF
--- a/src/com/jsyn/JSyn.java
+++ b/src/com/jsyn/JSyn.java
@@ -56,10 +56,10 @@ public class JSyn {
     // Update these for every release.
     private final static int VERSION_MAJOR = 16;
     private final static int VERSION_MINOR = 7;
-    private final static int VERSION_REVISION = 5;
-    public final static int BUILD_NUMBER = 459;
-    private final static long BUILD_TIME = new GregorianCalendar(2015, GregorianCalendar.NOVEMBER,
-            2).getTime().getTime();
+    private final static int VERSION_REVISION = 6;
+    public final static int BUILD_NUMBER = 460;
+    private final static long BUILD_TIME = new GregorianCalendar(2016,
+            GregorianCalendar.AUGUST, 9).getTime().getTime();
 
     public final static String VERSION = VERSION_MAJOR + "." + VERSION_MINOR + "."
             + VERSION_REVISION;

--- a/src/com/jsyn/devices/javasound/JavaSoundAudioDevice.java
+++ b/src/com/jsyn/devices/javasound/JavaSoundAudioDevice.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ import com.jsyn.devices.AudioDeviceOutputStream;
 
 /**
  * Use JavaSound to access the audio hardware.
- * 
+ *
  * @author Phil Burk (C) 2009 Mobileer Inc
  */
 public class JavaSoundAudioDevice implements AudioDeviceManager {
@@ -228,9 +228,6 @@ public class JavaSoundAudioDevice implements AudioDeviceManager {
                 bytes[byteIndex++] = (byte) sample; // little end
                 bytes[byteIndex++] = (byte) (sample >> 8); // big end
             }
-
-            // sleepUntilNonBlocking( byteIndex ); // This was just an attempt to get rid of clicks
-            // on Apple.
 
             line.write(bytes, 0, byteIndex);
         }


### PR DESCRIPTION
An overlap between stopping and starting could result in a closed audio device.

Fix involves moving device start/stop inside the audio thread.

https://github.com/philburk/jsyn/issues/30
