### PR TITLE
examples: remove SLF4J dependency

### DIFF
--- a/examples/src/main/java/com/jsyn/examples/AudioPassThrough.java
+++ b/examples/src/main/java/com/jsyn/examples/AudioPassThrough.java
@@ -21,8 +21,6 @@ import com.jsyn.Synthesizer;
 import com.jsyn.devices.AudioDeviceManager;
 import com.jsyn.unitgen.LineIn;
 import com.jsyn.unitgen.LineOut;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Pass audio input to audio output.
@@ -30,8 +28,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class AudioPassThrough {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AudioPassThrough.class);
 
     private void test() {
         LineIn lineIn;
@@ -55,7 +51,6 @@ public class AudioPassThrough {
 
         // We only need to start the LineOut. It will pull data from the LineIn.
         lineOut.start();
-        LOGGER.debug("Audio passthrough started.");
         // Sleep a while.
         try {
             double time = synth.getCurrentTime();
@@ -66,7 +61,6 @@ public class AudioPassThrough {
         }
         // Stop everything.
         synth.stop();
-        LOGGER.debug("All done.");
     }
 
     public static void main(String[] args) {

--- a/examples/src/main/java/com/jsyn/examples/ChebyshevSong.java
+++ b/examples/src/main/java/com/jsyn/examples/ChebyshevSong.java
@@ -31,8 +31,6 @@ import com.jsyn.util.PseudoRandom;
 import com.jsyn.util.VoiceAllocator;
 import com.softsynth.math.AudioMath;
 import com.softsynth.shared.time.TimeStamp;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /***************************************************************
  * Play notes using a WaveShapingVoice. Allocate the notes using a VoiceAllocator.
@@ -40,8 +38,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class ChebyshevSong extends JApplet implements Runnable {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ChebyshevSong.class);
 
     private Synthesizer synth;
     private Add mixer;
@@ -179,7 +175,7 @@ public class ChebyshevSong extends JApplet implements Runnable {
                 synth.sleepUntil(nextTime - advanceTime);
             } while (go);
         } catch (InterruptedException e) {
-            LOGGER.error("Song exiting", e);
+            e.printStackTrace();
         }
     }
 }

--- a/examples/src/main/java/com/jsyn/examples/FFTPassthrough.java
+++ b/examples/src/main/java/com/jsyn/examples/FFTPassthrough.java
@@ -24,8 +24,6 @@ import com.jsyn.unitgen.SineOscillator;
 import com.jsyn.unitgen.SpectralFFT;
 import com.jsyn.unitgen.SpectralIFFT;
 import com.jsyn.unitgen.UnitOscillator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play a sine sweep through an FFT/IFFT pair.
@@ -33,8 +31,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class FFTPassthrough {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FFTPassthrough.class);
 
     private Synthesizer synth;
     private PassThrough center;
@@ -63,10 +59,12 @@ public class FFTPassthrough {
         // Add a stereo audio output unit.
         synth.add(lineOut = new LineOut());
 
-        // Connect the oscillator to both channels of the output.
+        // Oscillator => FFT
         center.output.connect(osc.frequency);
         lfo.output.connect(osc.frequency);
         osc.output.connect(fft.input);
+
+        // FFT => IFFT => LineOut
         fft.output.connect(ifft1.input);
         fft.output.connect(ifft2.input);
         ifft1.output.connect(0, lineOut.input, 0);
@@ -82,8 +80,8 @@ public class FFTPassthrough {
         // chain.
         lineOut.start();
 
-        LOGGER.debug("You should now be hearing a clean oscillator on the left channel,");
-        LOGGER.debug("and the FFT->IFFT processed signal on the right channel.");
+        System.out.println("You should now be hearing a clean oscillator on the left channel,");
+        System.out.println("and the FFT->IFFT processed signal on the right channel.");
 
         // Sleep while the sound is generated in the background.
         try {
@@ -94,7 +92,7 @@ public class FFTPassthrough {
             e.printStackTrace();
         }
 
-        LOGGER.debug("Stop playing. -------------------");
+        System.out.println("Stop playing. -------------------");
         // Stop everything.
         synth.stop();
     }

--- a/examples/src/main/java/com/jsyn/examples/HearDAHDSR.java
+++ b/examples/src/main/java/com/jsyn/examples/HearDAHDSR.java
@@ -33,17 +33,15 @@ import com.jsyn.unitgen.LineOut;
 import com.jsyn.unitgen.SineOscillator;
 import com.jsyn.unitgen.SquareOscillator;
 import com.jsyn.unitgen.UnitOscillator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Play a tone using a JSyn oscillator. Modulate the amplitude using a DAHDSR envelope.
+ * Play a tone using a JSyn oscillator.
+ * Modulate the amplitude using a DAHDSR envelope.
  *
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class HearDAHDSR extends JApplet {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HearDAHDSR.class);
 
     private Synthesizer synth;
     private UnitOscillator osc;
@@ -92,11 +90,7 @@ public class HearDAHDSR extends JApplet {
     }
 
     private void setupPortKnob(UnitInputPort port) {
-
         DoubleBoundedRangeModel model = PortModelFactory.createExponentialModel(port);
-        LOGGER.debug("Make knob for " + port.getName() + ", model.getDV = "
-                + model.getDoubleValue() + ", model.getV = " + model.getValue() + ", port.getV = "
-                + port.get());
         RotaryTextController knob = new RotaryTextController(model, 10);
         knob.setBorder(BorderFactory.createTitledBorder(port.getName()));
         knob.setTitle(port.getName());

--- a/examples/src/main/java/com/jsyn/examples/HearSpectralFilter.java
+++ b/examples/src/main/java/com/jsyn/examples/HearSpectralFilter.java
@@ -31,8 +31,6 @@ import com.jsyn.unitgen.SpectralProcessor;
 import com.jsyn.unitgen.UnitOscillator;
 import com.jsyn.unitgen.WhiteNoise;
 import com.jsyn.util.WaveRecorder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play a sine sweep through an FFT/IFFT pair.
@@ -40,8 +38,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class HearSpectralFilter {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(HearSpectralFilter.class);
 
     private Synthesizer synth;
     private PassThrough center;
@@ -115,7 +111,7 @@ public class HearSpectralFilter {
             File waveFile = new File("temp_recording.wav");
             // Default is stereo, 16 bits.
             recorder = new WaveRecorder(synth, waveFile);
-            LOGGER.debug("Writing to WAV file " + waveFile.getAbsolutePath());
+            System.out.println("Writing to WAV file " + waveFile.getAbsolutePath());
         }
 
         if (useProcessor) {
@@ -178,8 +174,8 @@ public class HearSpectralFilter {
 
         lineOut.start();
 
-        LOGGER.debug("You should now be hearing a clean oscillator on the left channel,");
-        LOGGER.debug("and the FFT->IFFT processed signal on the right channel.");
+        System.out.println("You should now be hearing a noise+sawtooth on the left channel,");
+        System.out.println("and the FFT->IFFT processed signal on the right channel.");
 
         // Sleep while the sound is generated in the background.
         try {
@@ -195,7 +191,7 @@ public class HearSpectralFilter {
             recorder.close();
         }
 
-        LOGGER.debug("Stop playing. -------------------");
+        System.out.println("Stop playing. -------------------");
         // Stop everything.
         synth.stop();
     }

--- a/examples/src/main/java/com/jsyn/examples/ListAudioDevices.java
+++ b/examples/src/main/java/com/jsyn/examples/ListAudioDevices.java
@@ -18,12 +18,8 @@ package com.jsyn.examples;
 
 import com.jsyn.devices.AudioDeviceFactory;
 import com.jsyn.devices.AudioDeviceManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ListAudioDevices {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ListAudioDevices.class);
 
     /**
      * @param args
@@ -38,10 +34,10 @@ public class ListAudioDevices {
             int maxOutputs = audioManager.getMaxInputChannels(i);
             boolean isDefaultInput = (i == audioManager.getDefaultInputDeviceID());
             boolean isDefaultOutput = (i == audioManager.getDefaultOutputDeviceID());
-            LOGGER.debug("#" + i + " : " + deviceName);
-            LOGGER.debug("  max inputs : " + maxInputs
+            System.out.println("#" + i + " : " + deviceName);
+            System.out.println("  max inputs : " + maxInputs
                     + (isDefaultInput ? "   (default)" : ""));
-            LOGGER.debug("  max outputs: " + maxOutputs
+            System.out.println("  max outputs: " + maxOutputs
                     + (isDefaultOutput ? "   (default)" : ""));
         }
 

--- a/examples/src/main/java/com/jsyn/examples/LongEcho.java
+++ b/examples/src/main/java/com/jsyn/examples/LongEcho.java
@@ -30,8 +30,6 @@ import com.jsyn.unitgen.FixedRateMonoWriter;
 import com.jsyn.unitgen.Maximum;
 import com.jsyn.unitgen.Minimum;
 import com.jsyn.util.WaveFileWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Echo the input using a circular buffer in a sample.
@@ -39,8 +37,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class LongEcho {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(LongEcho.class);
 
     final static int DELAY_SECONDS = 4;
     Synthesizer synth;
@@ -89,7 +85,7 @@ public class LongEcho {
         // Loop both forever.
         reader.dataQueue.queueLoop(sample, 0, sample.getNumFrames());
         writer.dataQueue.queueLoop(sample, 0, sample.getNumFrames());
-        LOGGER.debug("Start talking. You should hear an echo after " + DELAY_SECONDS
+        System.out.println("Start talking. You should hear an echo after " + DELAY_SECONDS
                 + " seconds.");
         // Sleep a while.
         try {

--- a/examples/src/main/java/com/jsyn/examples/NotesToTone.java
+++ b/examples/src/main/java/com/jsyn/examples/NotesToTone.java
@@ -40,8 +40,6 @@ import com.jsyn.unitgen.UnitOscillator;
 import com.jsyn.unitgen.VariableRateDataReader;
 import com.jsyn.unitgen.VariableRateMonoReader;
 import com.jsyn.util.WaveRecorder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * When notes speed up they can become a new tone. <br>
@@ -52,8 +50,6 @@ import org.slf4j.LoggerFactory;
  */
 
 public class NotesToTone {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(NotesToTone.class);
 
     private final static double SONG_AMPLITUDE = 0.7;
     private final static double INTRO_DURATION = 2.0;
@@ -82,7 +78,7 @@ public class NotesToTone {
             File waveFile = new File("notes_to_tone.wav");
             // Default is stereo, 16 bits.
             recorder = new WaveRecorder(synth, waveFile, 1);
-            LOGGER.debug("Writing to WAV file " + waveFile.getAbsolutePath());
+            System.out.println("Writing to WAV file " + waveFile.getAbsolutePath());
         }
 
         createUnits();

--- a/examples/src/main/java/com/jsyn/examples/PlayFunction.java
+++ b/examples/src/main/java/com/jsyn/examples/PlayFunction.java
@@ -21,8 +21,6 @@ import com.jsyn.Synthesizer;
 import com.jsyn.data.Function;
 import com.jsyn.unitgen.FunctionOscillator;
 import com.jsyn.unitgen.LineOut;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play a tone using a FunctionOscillator.
@@ -30,8 +28,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlayFunction {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlayFunction.class);
 
     private void test() {
         // Create a context for the synthesizer.
@@ -69,7 +65,7 @@ public class PlayFunction {
         // oscillator.
         lineOut.start();
 
-        LOGGER.debug("You should now be hearing a sine wave. ---------");
+        System.out.println("You should now hear a sine wave for a few seconds.");
 
         // Sleep while the sound is generated in the background.
         try {
@@ -80,7 +76,7 @@ public class PlayFunction {
             e.printStackTrace();
         }
 
-        LOGGER.debug("Stop playing. -------------------");
+        System.out.println("Stop playing.");
         // Stop everything.
         synth.stop();
     }

--- a/examples/src/main/java/com/jsyn/examples/PlayGrains.java
+++ b/examples/src/main/java/com/jsyn/examples/PlayGrains.java
@@ -41,8 +41,6 @@ import com.jsyn.unitgen.LineOut;
 import com.jsyn.unitgen.SampleGrainFarm;
 import com.jsyn.util.SampleLoader;
 import com.jsyn.util.WaveRecorder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play with Granular Synthesis tools.
@@ -50,8 +48,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2011 Mobileer Inc
  */
 public class PlayGrains extends JApplet {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlayGrains.class);
 
     private Synthesizer synth;
     private LineOut lineOut;
@@ -148,7 +144,7 @@ public class PlayGrains extends JApplet {
                 File waveFile = new File("temp_recording.wav");
                 // Record mono 16 bits.
                 recorder = new WaveRecorder(synth, waveFile, 1);
-                LOGGER.debug("Writing to WAV file " + waveFile.getAbsolutePath());
+                System.out.println("Writing to WAV file " + waveFile.getAbsolutePath());
             }
 
             if (useSample) {

--- a/examples/src/main/java/com/jsyn/examples/PlayMIDI.java
+++ b/examples/src/main/java/com/jsyn/examples/PlayMIDI.java
@@ -26,8 +26,6 @@ import com.jsyn.midi.MidiSynthesizer;
 import com.jsyn.unitgen.LineOut;
 import com.jsyn.util.MultiChannelSynthesizer;
 import com.jsyn.util.VoiceDescription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Send MIDI messages to JSyn based MIDI synthesizer.
@@ -35,8 +33,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlayMIDI {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlayMIDI.class);
 
     private static final int NUM_CHANNELS = 16;
     private static final int VOICES_PER_CHANNEL = 6;
@@ -52,7 +48,6 @@ public class PlayMIDI {
         try {
             VoiceDescription description = DualOscillatorSynthVoice.getVoiceDescription();
             app.test(description);
-            LOGGER.debug("Test complete");
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
@@ -144,7 +139,7 @@ public class PlayMIDI {
         float range0 = 12.0f;
         sendPitchBendRange(0, range0);
         for(int i = 0; i < 13; i++) {
-            LOGGER.debug("Bend to pitch " + i);
+            System.out.println("Bend to pitch " + i);
             sendPitchBend(0, i / range0);
             sendNoteOn(0, 60, 100);
             synth.sleepFor(0.5);
@@ -163,7 +158,7 @@ public class PlayMIDI {
         sendPitchBend(0, 0.0f / range0); // bend by 0 semitones
         sendPitchBend(1, 1.0f / range1); // bend by 1 semitones
 
-        LOGGER.debug("These two notes should play at the same pitch.");
+        System.out.println("These two notes should play at the same pitch.");
         sendNoteOn(0, 61, 100);
         synth.sleepFor(0.5);
         sendNoteOff(0, 61, 100);
@@ -173,7 +168,7 @@ public class PlayMIDI {
         sendNoteOff(1, 60, 100);
 
         synth.sleepFor(2.0);
-        LOGGER.debug("------ done ---------------");
+        System.out.println("------ done ---------------");
     }
 
     /**

--- a/examples/src/main/java/com/jsyn/examples/PlayNotes.java
+++ b/examples/src/main/java/com/jsyn/examples/PlayNotes.java
@@ -21,8 +21,6 @@ import com.jsyn.Synthesizer;
 import com.jsyn.unitgen.LineOut;
 import com.jsyn.unitgen.SawtoothOscillator;
 import com.softsynth.shared.time.TimeStamp;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play notes using timestamped noteOn and noteOff methods of the UnitVoice.
@@ -30,8 +28,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2009 Mobileer Inc
  */
 public class PlayNotes {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlayNotes.class);
 
     private void test() {
 
@@ -86,9 +82,7 @@ public class PlayNotes {
 
         // Sleep while the song is being generated in the background thread.
         try {
-            LOGGER.debug("Sleep while synthesizing.");
             synth.sleepUntil(timeStamp.getTime() + 2.0);
-            LOGGER.debug("Woke up...");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/examples/src/main/java/com/jsyn/examples/PlayPartials.java
+++ b/examples/src/main/java/com/jsyn/examples/PlayPartials.java
@@ -23,8 +23,6 @@ import com.jsyn.unitgen.LinearRamp;
 import com.jsyn.unitgen.Multiply;
 import com.jsyn.unitgen.SineOscillator;
 import com.jsyn.unitgen.UnitOscillator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play a enharmonic sine tones using JSyn oscillators.
@@ -32,8 +30,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlayPartials {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlayPartials.class);
 
     private Synthesizer synth;
     private UnitOscillator[] osc;
@@ -90,8 +86,6 @@ public class PlayPartials {
         // oscillator.
         lineOut.start();
 
-        LOGGER.debug("You should now be hearing a sine wave. ---------");
-
         // Sleep while the sound is generated in the background.
         try {
             // Sleep for a few seconds.
@@ -102,14 +96,11 @@ public class PlayPartials {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-
-        LOGGER.debug("Stop playing. -------------------");
         // Stop everything.
         synth.stop();
     }
 
     public static void main(String[] args) {
-        LOGGER.debug("Java version = " + System.getProperty("java.version"));
         new PlayPartials().test();
     }
 }

--- a/examples/src/main/java/com/jsyn/examples/PlaySample.java
+++ b/examples/src/main/java/com/jsyn/examples/PlaySample.java
@@ -28,8 +28,6 @@ import com.jsyn.unitgen.VariableRateDataReader;
 import com.jsyn.unitgen.VariableRateMonoReader;
 import com.jsyn.unitgen.VariableRateStereoReader;
 import com.jsyn.util.SampleLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play a sample from a WAV file using JSyn.
@@ -37,8 +35,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlaySample {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlaySample.class);
 
     private Synthesizer synth;
     private VariableRateDataReader samplePlayer;
@@ -65,11 +61,11 @@ public class PlaySample {
             // Load the sample and display its properties.
             SampleLoader.setJavaSoundPreferred(false);
             sample = SampleLoader.loadFloatSample(sampleFile);
-            LOGGER.debug("Sample has: channels  = " + sample.getChannelsPerFrame());
-            LOGGER.debug("            frames    = " + sample.getNumFrames());
-            LOGGER.debug("            rate      = " + sample.getFrameRate());
-            LOGGER.debug("            loopStart = " + sample.getSustainBegin());
-            LOGGER.debug("            loopEnd   = " + sample.getSustainEnd());
+            System.out.println("Sample has: channels  = " + sample.getChannelsPerFrame());
+            System.out.println("            frames    = " + sample.getNumFrames());
+            System.out.println("            rate      = " + sample.getFrameRate());
+            System.out.println("            loopStart = " + sample.getSustainBegin());
+            System.out.println("            loopEnd   = " + sample.getSustainEnd());
 
             if (sample.getChannelsPerFrame() == 1) {
                 synth.add(samplePlayer = new VariableRateMonoReader());
@@ -94,13 +90,13 @@ public class PlaySample {
             // We can simply queue the entire file.
             // Or if it has a loop we can play the loop for a while.
             if (sample.getSustainBegin() < 0) {
-                LOGGER.debug("queue the sample");
+                System.out.println("queue the sample");
                 samplePlayer.dataQueue.queue(sample);
             } else {
-                LOGGER.debug("queueOn the sample");
+                System.out.println("queueOn the sample for a short time");
                 samplePlayer.dataQueue.queueOn(sample);
                 synth.sleepFor(8.0);
-                LOGGER.debug("queueOff the sample");
+                System.out.println("queueOff the sample");
                 samplePlayer.dataQueue.queueOff(sample);
             }
 

--- a/examples/src/main/java/com/jsyn/examples/PlaySampleCrossfade.java
+++ b/examples/src/main/java/com/jsyn/examples/PlaySampleCrossfade.java
@@ -39,8 +39,6 @@ import com.jsyn.unitgen.VariableRateDataReader;
 import com.jsyn.unitgen.VariableRateMonoReader;
 import com.jsyn.unitgen.VariableRateStereoReader;
 import com.jsyn.util.SampleLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play a sample from a WAV file using JSyn. Use a crossfade to play a loop at an arbitrary
@@ -49,8 +47,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlaySampleCrossfade extends JApplet {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlaySampleCrossfade.class);
 
     private static final double LOOP_START_FRACTION = 0.2;
     private Synthesizer synth;
@@ -81,11 +77,6 @@ public class PlaySampleCrossfade extends JApplet {
             // Load the sample and display its properties.
             SampleLoader.setJavaSoundPreferred(false);
             sample = SampleLoader.loadFloatSample(sampleFile);
-            LOGGER.debug("Sample has: channels  = " + sample.getChannelsPerFrame());
-            LOGGER.debug("            frames    = " + sample.getNumFrames());
-            LOGGER.debug("            rate      = " + sample.getFrameRate());
-            LOGGER.debug("            loopStart = " + sample.getSustainBegin());
-            LOGGER.debug("            loopEnd   = " + sample.getSustainEnd());
 
             if (sample.getChannelsPerFrame() == 1) {
                 synth.add(samplePlayer = new VariableRateMonoReader());
@@ -114,7 +105,7 @@ public class PlaySampleCrossfade extends JApplet {
         add(PortControllerFactory.createExponentialPortSlider(samplePlayer.rate));
 
         // Use fader to select arbitrary loop size.
-        rangeModelSize = new DoubleBoundedRangeModel("LoopSize", 10000, 0.01,
+        rangeModelSize = new DoubleBoundedRangeModel("LoopSize (fraction)", 10000, 0.01,
                 (1.0 - LOOP_START_FRACTION), 0.5);
         rangeModelSize.addChangeListener(new ChangeListener() {
             @Override
@@ -126,7 +117,7 @@ public class PlaySampleCrossfade extends JApplet {
         add(new DoubleBoundedRangeSlider(rangeModelSize, 3));
 
         // Use fader to set the size of the crossfade region.
-        rangeModelCrossfade = new DoubleBoundedRangeModel("Crossfade", 1000, 0.0, 1000.0, 0.0);
+        rangeModelCrossfade = new DoubleBoundedRangeModel("Crossfade (samples)", 1000, 0.0, 1000.0, 0.0);
         rangeModelCrossfade.addChangeListener(new ChangeListener() {
             @Override
             public void stateChanged(ChangeEvent e) {
@@ -154,7 +145,6 @@ public class PlaySampleCrossfade extends JApplet {
         command.setSkipIfOthers(true);
         command.setCrossFadeIn(crossFadeSize);
 
-        LOGGER.debug("Queue: " + loopStartFrame + ", #" + loopSize + ", X=" + crossFadeSize);
         synth.queueCommand(command);
     }
 

--- a/examples/src/main/java/com/jsyn/examples/PlaySampleWaveShaper.java
+++ b/examples/src/main/java/com/jsyn/examples/PlaySampleWaveShaper.java
@@ -27,17 +27,14 @@ import com.jsyn.unitgen.FunctionEvaluator;
 import com.jsyn.unitgen.LineOut;
 import com.jsyn.unitgen.SineOscillator;
 import com.jsyn.util.SampleLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Play a sample from a WAV file using JSyn.
+ * Play parts of a sample from a WAV file using
+ * a FunctionEvaluator. This technique can be used to create a "scratcher" app.
  *
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlaySampleWaveShaper {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlaySampleWaveShaper.class);
 
     private Synthesizer synth;
     private LineOut lineOut;
@@ -60,25 +57,14 @@ public class PlaySampleWaveShaper {
             // Add an output mixer.
             synth.add(lineOut = new LineOut());
 
-            // Load the sample and display its properties.
+            // Load the sample.
             SampleLoader.setJavaSoundPreferred(false);
             sample = SampleLoader.loadFloatSample(sampleFile);
-            LOGGER.debug("Sample has: channels  = " + sample.getChannelsPerFrame());
-            LOGGER.debug("            frames    = " + sample.getNumFrames());
-            LOGGER.debug("            rate      = " + sample.getFrameRate());
-            LOGGER.debug("            loopStart = " + sample.getSustainBegin());
-            LOGGER.debug("            loopEnd   = " + sample.getSustainEnd());
-
             if (sample.getChannelsPerFrame() != 1) {
                 throw new RuntimeException("Can only use mono samples.");
             }
 
-            LOGGER.debug("eval -1.1 = " + sample.evaluate(-1.1));
-            LOGGER.debug("eval -1.0 = " + sample.evaluate(-1.0));
-            LOGGER.debug("eval 0.3 = " + sample.evaluate(0.3));
-            LOGGER.debug("eval 1.0 = " + sample.evaluate(1.0));
-            LOGGER.debug("eval 1.1 = " + sample.evaluate(1.1));
-
+            // Use the sample as a lookup table for the function.
             FunctionEvaluator shaper = new FunctionEvaluator();
             shaper.function.set(sample);
             synth.add(shaper);
@@ -86,6 +72,7 @@ public class PlaySampleWaveShaper {
             shaper.output.connect(0, lineOut.input, 0);
             shaper.output.connect(0, lineOut.input, 1);
 
+            // Use a sine wave as the input to the function.
             SineOscillator osc = new SineOscillator();
             osc.frequency.set(0.2);
             osc.output.connect(shaper.input);

--- a/examples/src/main/java/com/jsyn/examples/PlaySegmentedEnvelope.java
+++ b/examples/src/main/java/com/jsyn/examples/PlaySegmentedEnvelope.java
@@ -28,8 +28,6 @@ import com.jsyn.unitgen.UnitOscillator;
 import com.jsyn.unitgen.VariableRateDataReader;
 import com.jsyn.unitgen.VariableRateMonoReader;
 import com.jsyn.util.WaveRecorder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Modulate the amplitude of an oscillator using a segmented envelope.
@@ -37,8 +35,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlaySegmentedEnvelope {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlaySegmentedEnvelope.class);
 
     private Synthesizer synth;
     private UnitOscillator osc;
@@ -60,7 +56,7 @@ public class PlaySegmentedEnvelope {
             File waveFile = new File("temp_recording.wav");
             // Default is stereo, 16 bits.
             recorder = new WaveRecorder(synth, waveFile);
-            LOGGER.debug("Writing to WAV file " + waveFile.getAbsolutePath());
+            System.out.println("Writing to WAV file " + waveFile.getAbsolutePath());
         }
 
         // Create an envelope consisting of (duration,value) pairs.

--- a/examples/src/main/java/com/jsyn/examples/PlaySegmentedEnvelopeCallback.java
+++ b/examples/src/main/java/com/jsyn/examples/PlaySegmentedEnvelopeCallback.java
@@ -27,8 +27,6 @@ import com.jsyn.unitgen.SawtoothOscillatorBL;
 import com.jsyn.unitgen.UnitOscillator;
 import com.jsyn.unitgen.VariableRateDataReader;
 import com.jsyn.unitgen.VariableRateMonoReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Use a UnitDataQueueCallback to notify us of the envelope's progress. Modulate the amplitude of an
@@ -37,8 +35,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlaySegmentedEnvelopeCallback {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlaySegmentedEnvelopeCallback.class);
 
     private Synthesizer synth;
     private UnitOscillator osc;
@@ -75,8 +71,9 @@ public class PlaySegmentedEnvelopeCallback {
 
         try {
             // Queue an envelope with callbacks.
-            QueueDataCommand command = envelopePlayer.dataQueue.createQueueDataCommand(envelope, 0,
-                    envelope.getNumFrames());
+            QueueDataCommand command =
+                    envelopePlayer.dataQueue.createQueueDataCommand(
+                            envelope, 0, envelope.getNumFrames());
             // Create an object to be called when the queued data is done.
             TestQueueCallback callback = new TestQueueCallback();
             command.setCallback(callback);
@@ -95,17 +92,17 @@ public class PlaySegmentedEnvelopeCallback {
     class TestQueueCallback implements UnitDataQueueCallback {
         @Override
         public void started(QueueDataEvent event) {
-            LOGGER.debug("CALLBACK: Envelope started.");
+            System.out.println("CALLBACK: Envelope started.");
         }
 
         @Override
         public void looped(QueueDataEvent event) {
-            LOGGER.debug("CALLBACK: Envelope looped.");
+            System.out.println("CALLBACK: Envelope looped.");
         }
 
         @Override
         public void finished(QueueDataEvent event) {
-            LOGGER.debug("CALLBACK: Envelope finished.");
+            System.out.println("CALLBACK: Envelope finished.");
             // Queue the envelope again at a faster rate.
             // (If this hangs we may have hit a deadlock.)
             envelopePlayer.rate.set(2.0);

--- a/examples/src/main/java/com/jsyn/examples/PlayTone.java
+++ b/examples/src/main/java/com/jsyn/examples/PlayTone.java
@@ -20,8 +20,6 @@ import com.jsyn.JSyn;
 import com.jsyn.Synthesizer;
 import com.jsyn.unitgen.LineOut;
 import com.jsyn.unitgen.SineOscillator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Play a tone using a JSyn oscillator.
@@ -29,8 +27,6 @@ import org.slf4j.LoggerFactory;
  * @author Phil Burk (C) 2010 Mobileer Inc
  */
 public class PlayTone {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlayTone.class);
 
     private void test() {
 
@@ -59,19 +55,15 @@ public class PlayTone {
         // oscillator.
         lineOut.start();
 
-        LOGGER.debug("You should now be hearing a sine wave. ---------");
-
         // Sleep while the sound is generated in the background.
         try {
             double time = synth.getCurrentTime();
-            LOGGER.debug("time = " + time);
             // Sleep for a few seconds.
             synth.sleepUntil(time + 4.0);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
 
-        LOGGER.debug("Stop playing. -------------------");
         // Stop everything.
         synth.stop();
     }

--- a/examples/src/main/java/com/jsyn/examples/RecordSineSweep.java
+++ b/examples/src/main/java/com/jsyn/examples/RecordSineSweep.java
@@ -34,12 +34,8 @@ import com.jsyn.unitgen.SawtoothOscillatorBL;
 import com.jsyn.unitgen.SineOscillator;
 import com.jsyn.unitgen.UnitOscillator;
 import com.jsyn.util.WaveRecorder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RecordSineSweep {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RecordSineSweep.class);
 
     final static double SONG_DURATION = 4.0;
     private Synthesizer synth;
@@ -59,8 +55,9 @@ public class RecordSineSweep {
             File waveFile = new File("temp_recording.wav");
             // Default is stereo, 16 bits.
             recorder = new WaveRecorder(synth, waveFile);
-            LOGGER.debug("Writing to WAV file " + waveFile.getAbsolutePath());
+            System.out.println("Writing to WAV file " + waveFile.getAbsolutePath());
         }
+
         // Add some tone generators.
         synth.add(leftOsc = new SineOscillator());
         synth.add(rightOsc = new SawtoothOscillatorBL());
@@ -106,7 +103,7 @@ public class RecordSineSweep {
 
         // Test stopping and restarting a recorder. This will cause a pop.
         if (recorder != null) {
-            LOGGER.debug("Stop and restart recorder.");
+            System.out.println("Stop and restart recorder.");
             recorder.stop();
         }
         sweeper.input.set(100.0);

--- a/examples/src/main/java/com/jsyn/examples/UseMidiKeyboard.java
+++ b/examples/src/main/java/com/jsyn/examples/UseMidiKeyboard.java
@@ -31,8 +31,6 @@ import com.jsyn.midi.MidiSynthesizer;
 import com.jsyn.unitgen.LineOut;
 import com.jsyn.util.MultiChannelSynthesizer;
 import com.jsyn.util.VoiceDescription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Connect a USB MIDI Keyboard to the internal MIDI Synthesizer using JavaSound.
@@ -41,7 +39,6 @@ import org.slf4j.LoggerFactory;
  */
 public class UseMidiKeyboard {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UseMidiKeyboard.class);
     private static final int NUM_CHANNELS = 16;
     private static final int VOICES_PER_CHANNEL = 3;
 
@@ -91,10 +88,10 @@ public class UseMidiKeyboard {
             // Put the receiver in the transmitter.
             // This gives fairly low latency playing.
             keyboard.getTransmitter().setReceiver(receiver);
-            LOGGER.debug("Play MIDI keyboard: " + keyboard.getDeviceInfo().getDescription());
+            System.out.println("Play MIDI keyboard: " + keyboard.getDeviceInfo().getDescription());
             result = 0;
         } else {
-            LOGGER.debug("Could not find a keyboard.");
+            System.out.println("Could not find a keyboard.");
         }
         return result;
     }


### PR DESCRIPTION
Use System.out.println() instead.
These example are intended to write to the console.
A recent change that added gradle support broke this feature.