### PR TITLE
Remove LOGGER references and a '== Double.NaN' check

### DIFF
--- a/android/com/jsyn/devices/android/AndroidAudioForJSyn.java
+++ b/android/com/jsyn/devices/android/AndroidAudioForJSyn.java
@@ -84,9 +84,9 @@ public class AndroidAudioForJSyn implements AudioDeviceManager {
             minBufferSize = AudioTrack.getMinBufferSize(frameRate,
                     AudioFormat.CHANNEL_OUT_STEREO,
                     AudioFormat.ENCODING_PCM_FLOAT);
-            LOGGER.debug("Audio minBufferSize = " + minBufferSize);
+            // LOGGER.debug("Audio minBufferSize = " + minBufferSize);
             bufferSize = (3 * (minBufferSize / 2)) & ~3;
-            LOGGER.debug("Audio bufferSize = " + bufferSize);
+            // LOGGER.debug("Audio bufferSize = " + bufferSize);
             audioTrack = new AudioTrack(AudioManager.STREAM_MUSIC, frameRate,
                     AudioFormat.CHANNEL_OUT_STEREO,
                     AudioFormat.ENCODING_PCM_FLOAT, bufferSize,

--- a/src/main/java/com/jsyn/io/AudioFifo.java
+++ b/src/main/java/com/jsyn/io/AudioFifo.java
@@ -173,7 +173,7 @@ public class AudioFifo implements AudioInputStream, AudioOutputStream {
         int numRead = 0;
         for (int i = 0; mOpen && i < count; i++) {
             double value = read();
-            if (value == Double.NaN) break;
+            if (Double.isNaN(value)) break;
             buffer[i + start] = value;
             numRead++;
         }


### PR DESCRIPTION
Both changes are necessary to build as a dependency of the ExoPlayer library.