### PR TITLE
midi: fixes for ExoSynth

### DIFF
--- a/src/main/java/com/jsyn/midi/MessageParser.java
+++ b/src/main/java/com/jsyn/midi/MessageParser.java
@@ -105,7 +105,6 @@ public class MessageParser {
                 break;
             case MidiConstants.CONTROLLER_NRPN_MSB:
                 parameterIndices[channel] = (value << 7) | BIT_NON_RPM;
-                ;
                 break;
             case MidiConstants.CONTROLLER_RPN_LSB:
                 paramIndex = parameterIndices[channel] & ~0x7F;

--- a/src/main/java/com/jsyn/midi/MessageParser.java
+++ b/src/main/java/com/jsyn/midi/MessageParser.java
@@ -87,7 +87,7 @@ public class MessageParser {
     public void rawControlChange(int channel, int index, int value) {
         int paramIndex;
         int paramValue;
-        switch(index) {
+        switch (index) {
             case MidiConstants.CONTROLLER_DATA_ENTRY:
                 parameterValues[channel] = value << 7;
                 fireParameterChange(channel);
@@ -104,7 +104,8 @@ public class MessageParser {
                 parameterIndices[channel] = paramIndex;
                 break;
             case MidiConstants.CONTROLLER_NRPN_MSB:
-                parameterIndices[channel] = (value << 7) | BIT_NON_RPM;;
+                parameterIndices[channel] = (value << 7) | BIT_NON_RPM;
+                ;
                 break;
             case MidiConstants.CONTROLLER_RPN_LSB:
                 paramIndex = parameterIndices[channel] & ~0x7F;
@@ -133,12 +134,8 @@ public class MessageParser {
 
     private void checkMessageLength(int expectedLength, int actualLength) {
         if (actualLength < expectedLength) {
-            throw new IllegalArgumentException(
-                "Expected message of at least "
-                    + expectedLength
-                    + " bytes but got "
-                    + actualLength
-                    + " bytes.");
+            throw new IllegalArgumentException("Expected message of at least " + expectedLength
+                    + " bytes but got " + actualLength + " bytes.");
         }
     }
 

--- a/src/main/java/com/jsyn/midi/MidiSynthesizer.java
+++ b/src/main/java/com/jsyn/midi/MidiSynthesizer.java
@@ -19,26 +19,26 @@ package com.jsyn.midi;
 import com.jsyn.util.MultiChannelSynthesizer;
 
 /**
- * Map MIDI messages into calls to a MultiChannelSynthesizer.
- * Handles CONTROLLER_MOD_WHEEL, TIMBRE, VOLUME and PAN.
- * Handles Bend Range RPN.
+ * Map MIDI messages into calls to a MultiChannelSynthesizer. Handles CONTROLLER_MOD_WHEEL, TIMBRE,
+ * VOLUME and PAN. Handles Bend Range RPN.
  *
- * <pre><code>
-    voiceDescription = DualOscillatorSynthVoice.getVoiceDescription();
-    multiSynth = new MultiChannelSynthesizer();
-    final int startChannel = 0;
-    multiSynth.setup(synth, startChannel, NUM_CHANNELS, VOICES_PER_CHANNEL, voiceDescription);
-    midiSynthesizer = new MidiSynthesizer(multiSynth);
-    // pass MIDI bytes
-    midiSynthesizer.onReceive(bytes, 0, bytes.length);
-    </code></pre>
+ * <pre>
+ * <code>
+ voiceDescription = DualOscillatorSynthVoice.getVoiceDescription();
+ multiSynth = new MultiChannelSynthesizer();
+ final int startChannel = 0;
+ multiSynth.setup(synth, startChannel, NUM_CHANNELS, VOICES_PER_CHANNEL, voiceDescription);
+ midiSynthesizer = new MidiSynthesizer(multiSynth);
+ // pass MIDI bytes
+ midiSynthesizer.onReceive(bytes, 0, bytes.length);
+ </code>
+ * </pre>
  *
  * See the example UseMidiKeyboard.java
  *
  * @author Phil Burk (C) 2016 Mobileer Inc
  */
 public class MidiSynthesizer extends MessageParser {
-
 
     private MultiChannelSynthesizer multiSynth;
 
@@ -48,7 +48,7 @@ public class MidiSynthesizer extends MessageParser {
 
     @Override
     public void controlChange(int channel, int index, int value) {
-        //LOGGER.debug("controlChange(" + channel + ", " + index + ", " + value + ")");
+        // LOGGER.debug("controlChange(" + channel + ", " + index + ", " + value + ")");
         double normalized = value * (1.0 / 127.0);
         switch (index) {
             case MidiConstants.CONTROLLER_MOD_WHEEL:
@@ -70,7 +70,7 @@ public class MidiSynthesizer extends MessageParser {
 
     @Override
     public void registeredParameter(int channel, int index14, int value14) {
-        switch(index14) {
+        switch (index14) {
             case MidiConstants.RPN_BEND_RANGE:
                 int semitones = value14 >> 7;
                 int cents = value14 & 0x7F;


### PR DESCRIPTION
Combine channel and noteNumber as a tag for the VoiceAllocator
to avoid collisions when the same note is played on multiple channels.

Allocate more voices: numChannels * voicesPerChannel

For GM2 synths, force channel 10 (9) to use preset 128.
That is a sign for the synth that this is a rhythm channel.