### PR TITLE
Fix maven publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ test {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            artifactId = 'jsyn'
+            from components.java
             pom {
                 name = 'JSyn'
                 description = 'Java synthesizer library with unit generators.'


### PR DESCRIPTION
This fixes an issue where Jitpack.io was not able to generate jar files after commit https://github.com/philburk/jsyn/commit/1e3b54c76da7b1173afde4675e4ec96713014a3b